### PR TITLE
Prevent irods-php from opening a file that does not exist.

### DIFF
--- a/src/RODSConn.class.php
+++ b/src/RODSConn.class.php
@@ -1048,6 +1048,12 @@ class RODSConn {
             $api_num = $GLOBALS['PRODS_API_NUMS']['DATA_OBJ_OPEN_AN'];
         }
 
+        # Don't try to read a file that does not exist.
+        if($file_exists === false && $open_flag == O_RDONLY) {
+                throw new RODSException("trying to open a file '$path' " .
+                "which does not exists with mode '$mode' ", "PERR_USER_INPUT_ERROR");
+        }
+
         $msg = new RODSMessage("RODS_API_REQ_T", $dataObjInp_pk, $api_num);
         fwrite($this->conn, $msg->pack());
 


### PR DESCRIPTION
This is a fix to prevent irods-php from opening a file that does not exist, which causes an internal server error when PAM is enabled on iRODS 4.2.x.